### PR TITLE
 Make sure the configuration directory exists 

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,7 +1,0 @@
-name    'morphizer-sabnzbd'
-version '0.1.2'
-author 'morphizer'
-license 'Apache License, Version 2.0'
-summary 'SABnzbd news reader install and configure'
-description 'SABnzbd is an Open Source Binary Newsreader written in Python. This module installs and configures it for use on Ubuntu/Debian based machines'
-project_page 'http://github.com/morphizer/puppet-sabnzbd'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,6 +101,8 @@ class sabnzbd (
   $categories     = {}
 ) inherits sabnzbd::params {
 
+  $config_dir = dirname($config_path)
+
   # make it run apt-get update first
   exec { "apt-update":
     command => "/usr/bin/apt-get update"
@@ -137,15 +139,12 @@ class sabnzbd (
     system     => true,
     managehome => true,
     require    => Package['sabnzbdplus'],
-  }
-
-  file { '/etc/default/sabnzbdplus':
-    ensure  => file,
-    require => Package['sabnzbdplus'],
-    content => template('sabnzbd/sabnzbdplus.erb'),
-    notify  => Service['sabnzbdplus'],
-  }
-
+  } ->
+  file {$config_dir:
+    ensure => 'directory',
+    owner  => $user,
+    group  => $user
+  } ->
   file { $config_path:
     ensure  => file,
     require => Package['sabnzbdplus'],
@@ -153,6 +152,13 @@ class sabnzbd (
     notify  => Service['sabnzbdplus'],
     owner   => $user,
     group   => $user
+  }
+
+  file { '/etc/default/sabnzbdplus':
+    ensure  => file,
+    require => Package['sabnzbdplus'],
+    content => template('sabnzbd/sabnzbdplus.erb'),
+    notify  => Service['sabnzbdplus'],
   }
 
   service { 'sabnzbdplus':

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "morphizer-sabnzbd",
+  "version": "0.1.2",
+  "author": "morphizer",
+  "summary": "SABnzbd news reader install and configure",
+  "license": "Apache License, Version 2.0",
+  "source": "https://github.com/morphizer/puppet-sabnzbd",
+  "project_page": "http://github.com/morphizer/puppet-sabnzbd",
+  "issues_url": "https://github.com/morphizer/puppet-sabnzbd/issues",
+  "description": "SABnzbd is an Open Source Binary Newsreader written in Python. This module installs and configures it for use on Ubuntu/Debian based machines",
+  "dependencies": [
+  
+  ]
+}

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,6 @@
   "issues_url": "https://github.com/morphizer/puppet-sabnzbd/issues",
   "description": "SABnzbd is an Open Source Binary Newsreader written in Python. This module installs and configures it for use on Ubuntu/Debian based machines",
   "dependencies": [
-  
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=4.5.0 <5.0.0" }
   ]
 }


### PR DESCRIPTION
If the user already exists, puppet does not create the home directory, so this
didn't work with the default configuration in that case

NOTE: This includes #7 to specify dependency on stdlib
